### PR TITLE
Fixes app crashing when background/foreground

### DIFF
--- a/ios/BlueshiftReactAutoIntegration.m
+++ b/ios/BlueshiftReactAutoIntegration.m
@@ -227,23 +227,15 @@
 
 #pragma mark - Application lifecycle methods
 - (void)blueshift_swizzled_applicationWillEnterForeground:(UIApplication *)application {
-    [self blueshift_swizzled_applicationWillEnterForeground:application];
-    
-    [[BlueShift sharedInstance].appDelegate appDidBecomeActive:application];
 }
 
 - (void)blueshift_swizzled_no_applicationWillEnterForeground:(UIApplication *)application {
-    [[BlueShift sharedInstance].appDelegate appDidBecomeActive:application];
 }
 
 - (void)blueshift_swizzled_applicationDidEnterBackground:(UIApplication *)application {
-    [self blueshift_swizzled_applicationDidEnterBackground:application];
-    
-    [[BlueShift sharedInstance].appDelegate appDidEnterBackground:application];
 }
 
 - (void)blueshift_swizzled_no_applicationDidEnterBackground:(UIApplication *)application {
-    [[BlueShift sharedInstance].appDelegate appDidEnterBackground:application];
 }
 
 #pragma mark - Universal links method


### PR DESCRIPTION
These methods were crashing our iOS app when backgrounding/foregrounding the app.

XCode warns about these deprecations:
'appDidBecomeActive:' is deprecated: SDK now automatically detects if app becomes active, this method will be removed in upcoming releases.
'appDidBecomeActive:' is deprecated: SDK now automatically detects if app becomes active, this method will be removed in upcoming releases.
'appDidEnterBackground:' is deprecated: SDK now automatically detects if app enters background, this method will be removed in upcoming releases.
'appDidEnterBackground:' is deprecated: SDK now automatically detects if app enters background, this method will be removed in upcoming releases.

But the actual crashes come from `[self blueshift_swizzled_applicationWillEnterForeground:application];` and `[self blueshift_swizzled_applicationDidEnterBackground:application];` and those crashes are `Thread 1: EXC_BAD_ACCESS (code=1, address=0x0)` and the relevant log for it is 

```
->  0x1290852b5 <+101>: leaq   0x82b12b(%rip), %rdi      ; "Application violated contract by causing UIApplicationMain() to return. This incident will be reported."
```

When I comment these out or remove them, the app doesn't crash and works as expected.