### PR TITLE
[MOBL-1548] Avoid repeated deep link callbacks

### DIFF
--- a/BlueshiftSampleApp/App.js
+++ b/BlueshiftSampleApp/App.js
@@ -6,6 +6,8 @@ import Blueshift from 'blueshift-react-native';
 export default class App extends Component {
 
 componentDidMount() { 
+  Blueshift.init();
+  
   // Get the email deep link when app launched from killed state
   Linking.getInitialURL().then(url => { 
     if(url) {
@@ -491,3 +493,48 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   }
 });
+
+
+// import React, { useEffect } from 'react';
+
+// const Root = () => {
+  
+//   Blueshift.identifyWithDetails({});
+
+//   useEffect(() => {
+
+//     console.log('useEffect: START');
+  
+
+//       // Add event listner for `url` event
+//   global.urlListener = Linking.addEventListener('url', (event) => { 
+//     var url = event.url;
+//     if(url) {
+//       // Check if the URL is a rewritten/shortened URL from Blueshift
+//       if (Blueshift.isBlueshiftUrl(url)) {
+//         Blueshift.processBlueshiftUrl(url);
+//       } else {
+//         console.log('handleDeeplink: ' + url);
+//         // this.handleDeeplinkUrl(url);
+//       }
+//     }
+//   });
+  
+//   Blueshift.addEventListener('PushNotificationClickedEvent', () =>{});
+  
+
+//     return () => {
+//       console.log('useEffect: return');
+//       global.urlListener.remove();  
+//     }
+//   }, [])
+  
+  
+//   return (
+//     <View style={{ flex: 1 }}>
+//       <Text>Hello</Text>
+//     </View>
+//   );
+// }
+
+// export default Root;

--- a/BlueshiftSampleApp/App.js
+++ b/BlueshiftSampleApp/App.js
@@ -5,9 +5,7 @@ import Blueshift from 'blueshift-react-native';
 
 export default class App extends Component {
 
-componentDidMount() { 
-  Blueshift.init();
-  
+componentDidMount() {   
   // Get the email deep link when app launched from killed state
   Linking.getInitialURL().then(url => { 
     if(url) {
@@ -32,6 +30,8 @@ componentDidMount() {
       }
     }
   }); 
+
+  Blueshift.init();
 
   // Add custom event listener using Blueshift method
   Blueshift.addEventListener('PushNotificationClickedEvent', this.handlePushClick);

--- a/BlueshiftSampleApp/android/app/src/main/AndroidManifest.xml
+++ b/BlueshiftSampleApp/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="com.blueshiftsampleapp">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -22,7 +23,9 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
 
-        <intent-filter android:label="ReactNativeApp">
+        <intent-filter android:label="ReactNativeApp" 
+                android:autoVerify="true"
+                tools:targetApi="m">
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />
             <category android:name="android.intent.category.BROWSABLE" />

--- a/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeEventHandler.java
+++ b/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeEventHandler.java
@@ -32,19 +32,21 @@ public class BlueshiftReactNativeEventHandler {
         }
     }
 
-    public void enqueueEvent(String eventName, Map<String, Object> params) {
+    public void enqueueEvent(String eventName, Map<String, Object> params, ReactContext context) {
         synchronized (mEventQueue) {
             mEventQueue.put(eventName, params);
         }
 
-        fireEvent(eventName);
+        fireEvent(eventName, context);
     }
 
-    public void fireEvent(String eventName) {
+    public void fireEvent(String eventName, ReactContext context) {
+        initEventEmitter(context);
+
         if (mEventEmitter == null) {
             int SYNC_DELAY = 500;
             BlueshiftLogger.d(TAG, "mEventEmitter not ready. Retrying in " + SYNC_DELAY + " ms.");
-            new Handler().postDelayed(() -> fireEvent(eventName), SYNC_DELAY);
+            new Handler().postDelayed(() -> fireEvent(eventName, context), SYNC_DELAY);
         } else if (eventName != null) {
             synchronized (mEventQueue) {
                 if (mEventQueue.containsKey(eventName)) {

--- a/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeEventHandler.java
+++ b/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeEventHandler.java
@@ -32,21 +32,19 @@ public class BlueshiftReactNativeEventHandler {
         }
     }
 
-    public void enqueueEvent(String eventName, Map<String, Object> params, ReactContext context) {
+    public void enqueueEvent(String eventName, Map<String, Object> params) {
         synchronized (mEventQueue) {
             mEventQueue.put(eventName, params);
         }
 
-        fireEvent(eventName, context);
+        fireEvent(eventName);
     }
 
-    public void fireEvent(String eventName, ReactContext context) {
-        initEventEmitter(context);
-
+    public void fireEvent(String eventName) {
         if (mEventEmitter == null) {
             int SYNC_DELAY = 500;
             BlueshiftLogger.d(TAG, "mEventEmitter not ready. Retrying in " + SYNC_DELAY + " ms.");
-            new Handler().postDelayed(() -> fireEvent(eventName, context), SYNC_DELAY);
+            new Handler().postDelayed(() -> fireEvent(eventName), SYNC_DELAY);
         } else if (eventName != null) {
             synchronized (mEventQueue) {
                 if (mEventQueue.containsKey(eventName)) {

--- a/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
+++ b/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
@@ -314,13 +314,14 @@ public class BlueshiftReactNativeModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     void onAddEventListener(String eventName) {
-        BlueshiftReactNativeEventHandler.getInstance().fireEvent(eventName, getReactApplicationContext());
+        BlueshiftReactNativeEventHandler.getInstance().initEventEmitter(getReactApplicationContext());
+        BlueshiftReactNativeEventHandler.getInstance().fireEvent(eventName);
 
         // This is to fire any pending "url" event in the queue so that RN can receive it.
         // For this to work, we should make sure that the Linking.addEventListener code is
         // written before calling the Blueshift.addEventListener method.
         if (!"url".equals(eventName)) {
-            BlueshiftReactNativeEventHandler.getInstance().fireEvent("url", getReactApplicationContext());
+            BlueshiftReactNativeEventHandler.getInstance().fireEvent("url");
         }
     }
 
@@ -341,10 +342,9 @@ public class BlueshiftReactNativeModule extends ReactContextBaseJavaModule {
             if (url == null || url.isEmpty()) {
                 BlueshiftLogger.w(TAG, "Null/Empty value found for deep_link_url.");
             } else {
-                ReactApplicationContext context = BlueshiftReactNativeModule.sInstance.getReactApplicationContext();
                 Map<String, Object> params = new HashMap<>();
                 params.put("url", url);
-                BlueshiftReactNativeEventHandler.getInstance().enqueueEvent("url", params, context);
+                BlueshiftReactNativeEventHandler.getInstance().enqueueEvent("url", params);
             }
 
             // remove the push deep link from intent to avoid

--- a/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
+++ b/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
@@ -2,6 +2,7 @@ package com.blueshift.reactnative;
 
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Bundle;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -348,6 +349,10 @@ public class BlueshiftReactNativeModule extends ReactContextBaseJavaModule {
             Map<String, Object> params = new HashMap<>();
             params.put("url", url);
             BlueshiftReactNativeEventHandler.getInstance().enqueueEvent("url", params);
+
+            // cleanup the intent's data and deep link string
+            intent.removeExtra(DEEP_LINK_URL);
+            intent.setData(Uri.EMPTY);
         }
     }
 

--- a/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
+++ b/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
@@ -52,7 +52,6 @@ public class BlueshiftReactNativeModule extends ReactContextBaseJavaModule {
 
     public BlueshiftReactNativeModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        BlueshiftReactNativeEventHandler.getInstance().initEventEmitter(reactContext);
     }
 
     @Override
@@ -315,13 +314,13 @@ public class BlueshiftReactNativeModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     void onAddEventListener(String eventName) {
-        BlueshiftReactNativeEventHandler.getInstance().fireEvent(eventName);
+        BlueshiftReactNativeEventHandler.getInstance().fireEvent(eventName, getReactApplicationContext());
 
         // This is to fire any pending "url" event in the queue so that RN can receive it.
         // For this to work, we should make sure that the Linking.addEventListener code is
         // written before calling the Blueshift.addEventListener method.
         if (!"url".equals(eventName)) {
-            BlueshiftReactNativeEventHandler.getInstance().fireEvent("url");
+            BlueshiftReactNativeEventHandler.getInstance().fireEvent("url", getReactApplicationContext());
         }
     }
 
@@ -342,9 +341,10 @@ public class BlueshiftReactNativeModule extends ReactContextBaseJavaModule {
             if (url == null || url.isEmpty()) {
                 BlueshiftLogger.w(TAG, "Null/Empty value found for deep_link_url.");
             } else {
+                ReactApplicationContext context = BlueshiftReactNativeModule.sInstance.getReactApplicationContext();
                 Map<String, Object> params = new HashMap<>();
                 params.put("url", url);
-                BlueshiftReactNativeEventHandler.getInstance().enqueueEvent("url", params);
+                BlueshiftReactNativeEventHandler.getInstance().enqueueEvent("url", params, context);
             }
 
             // remove the push deep link from intent to avoid

--- a/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
+++ b/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
@@ -60,6 +60,14 @@ public class BlueshiftReactNativeModule extends ReactContextBaseJavaModule {
         return NAME;
     }
 
+    // INITIALIZE
+
+    @ReactMethod
+    void init() {
+        BlueshiftReactNativeEventHandler.getInstance().initEventEmitter(getReactApplicationContext());
+        BlueshiftReactNativeEventHandler.getInstance().fireEvent("url");
+    }
+
     // USERINFO
 
     @ReactMethod
@@ -314,15 +322,7 @@ public class BlueshiftReactNativeModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     void onAddEventListener(String eventName) {
-        BlueshiftReactNativeEventHandler.getInstance().initEventEmitter(getReactApplicationContext());
         BlueshiftReactNativeEventHandler.getInstance().fireEvent(eventName);
-
-        // This is to fire any pending "url" event in the queue so that RN can receive it.
-        // For this to work, we should make sure that the Linking.addEventListener code is
-        // written before calling the Blueshift.addEventListener method.
-        if (!"url".equals(eventName)) {
-            BlueshiftReactNativeEventHandler.getInstance().fireEvent("url");
-        }
     }
 
     @ReactMethod

--- a/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
+++ b/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
@@ -336,8 +336,11 @@ public class BlueshiftReactNativeModule extends ReactContextBaseJavaModule {
     }
 
     public static void processBlueshiftPushUrl(Intent intent) {
+        BlueshiftLogger.d(TAG, "processBlueshiftPushUrl");
         if (intent != null && intent.hasExtra(DEEP_LINK_URL)) {
             String url = intent.getStringExtra(DEEP_LINK_URL);
+            BlueshiftLogger.d(TAG, "processBlueshiftPushUrl: " + url);
+
             Map<String, Object> params = new HashMap<>();
             params.put("url", url);
             BlueshiftReactNativeEventHandler.getInstance().enqueueEvent("url", params);

--- a/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
+++ b/android/src/main/java/com/blueshift/reactnative/BlueshiftReactNativeModule.java
@@ -339,7 +339,11 @@ public class BlueshiftReactNativeModule extends ReactContextBaseJavaModule {
         BlueshiftLogger.d(TAG, "processBlueshiftPushUrl");
         if (intent != null && intent.hasExtra(DEEP_LINK_URL)) {
             String url = intent.getStringExtra(DEEP_LINK_URL);
-            BlueshiftLogger.d(TAG, "processBlueshiftPushUrl: " + url);
+            BlueshiftLogger.d(TAG, "processBlueshiftPushUrl: url - " + url);
+            Uri data = intent.getData();
+            if (data != null) {
+                BlueshiftLogger.d(TAG, "processBlueshiftPushUrl: data - " + data.toString());
+            }
 
             Map<String, Object> params = new HashMap<>();
             params.put("url", url);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,14 @@
 declare module 'blueshift-react-native' {
 
 	/**
+	 * Initialise the plugin components when React Native is ready and loaded.
+	 * 
+	 * Usage -
+	 * Blueshift.init();
+	 */
+	function init(): void;
+
+	/**
 	 * Add event listener for a event name to listen to events fired by Blueshift SDK
 	 * 
 	 * Usage -

--- a/index.js
+++ b/index.js
@@ -5,6 +5,21 @@ const BlueshiftEventEmitter = new NativeEventEmitter(NativeModules.BlueshiftReac
 var Blueshift = {
 
     /**
+     * Initialize the components of the Blueshift SDK. This mainly initializes the
+     * event emitter instance to start firing the events when the app is ready to
+     * receive them.
+     * 
+     * Usage -
+     * Blueshift.init();
+     * 
+     */
+    init: function() {
+        if (Platform.OS === 'android') {
+            NativeModules.BlueshiftBridge.init();      
+        }
+    },
+
+    /**
      * Add event listener for a event name to listen to events fired by Blueshift SDK
      *
      * Usage - 


### PR DESCRIPTION
This fix removes the deep link from the Intent once consumed. This will prevent the app from getting into a loop of deep link callbacks when brought to the foreground from the background state.